### PR TITLE
Increase DB_MAX_OVERFLOW

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -86,7 +86,7 @@ class Settings(BaseSettings):
 
     DB_POOL_SIZE: int = 30
     DB_POOL_PRE_PING: bool = True
-    DB_MAX_OVERFLOW: int = 0
+    DB_MAX_OVERFLOW: int = 20
 
     @field_validator("DB_URI", mode="before")
     @classmethod


### PR DESCRIPTION
Increase DB_MAX_OVERFLOW to allow extra connections in case it's needed (similar to entitycore).
DB_POOL_SIZE can remain 30 since the current usage is between 10-15 connections.

Note that the value can be also overridden in terraform.