### PR TITLE
Add Sentry integration

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -9,6 +9,7 @@ import uvloop
 from app.config import settings
 from app.db.session import database_session_manager
 from app.logger import configure_logging
+from app.sentry import init_sentry
 from app.task.job_charger.longrun import PeriodicLongrunCharger
 from app.task.job_charger.oneshot import PeriodicOneshotCharger
 from app.task.job_charger.storage import PeriodicStorageCharger
@@ -20,6 +21,7 @@ from app.task.queue_consumer.storage import StorageQueueConsumer
 async def main() -> None:
     """Init and run all the async tasks."""
     configure_logging()
+    init_sentry()
     database_session_manager.initialize(
         url=settings.DB_URI,
         pool_size=settings.DB_POOL_SIZE,

--- a/app/config.py
+++ b/app/config.py
@@ -79,8 +79,8 @@ class Settings(BaseSettings):
     SQS_CLIENT_CONFIG: SQSClientConfig = SQSClientConfig()
 
     SENTRY_DSN: str | None = None
-    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
-    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
 
     DB_ENGINE: str = "postgresql+asyncpg"
     DB_USER: str = "accounting_service"

--- a/app/config.py
+++ b/app/config.py
@@ -80,7 +80,7 @@ class Settings(BaseSettings):
 
     SENTRY_DSN: str | None = None
     SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
-    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1.0
 
     DB_ENGINE: str = "postgresql+asyncpg"
     DB_USER: str = "accounting_service"

--- a/app/config.py
+++ b/app/config.py
@@ -1,8 +1,9 @@
 """Configuration."""
 
 from decimal import Decimal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, PostgresDsn, field_validator
+from pydantic import BaseModel, Field, PostgresDsn, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -32,6 +33,7 @@ class Settings(BaseSettings):
     APP_VERSION: str | None = None
     APP_DEBUG: bool = False
     COMMIT_SHA: str | None = None
+    DEPLOYMENT_ENV: Literal["local", "staging", "production"] = "local"
 
     UVICORN_PORT: int = 8000
 
@@ -75,6 +77,10 @@ class Settings(BaseSettings):
     SQS_LONGRUN_QUEUE_NAME: str = "longrun.fifo"
     SQS_CLIENT_ERROR_SLEEP: float = 10
     SQS_CLIENT_CONFIG: SQSClientConfig = SQSClientConfig()
+
+    SENTRY_DSN: str | None = None
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
 
     DB_ENGINE: str = "postgresql+asyncpg"
     DB_USER: str = "accounting_service"

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,0 +1,21 @@
+"""Sentry integration."""
+
+import sentry_sdk
+
+from app.config import settings
+
+
+def init_sentry() -> None:
+    """Initialize the Sentry SDK.
+
+    Must be called after ``configure_logging``, which removes all the loguru handlers,
+    including the ones registered by the Sentry loguru integration.
+    """
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.DEPLOYMENT_ENV,
+        release=settings.APP_VERSION,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        profile_session_sample_rate=settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE,
+        profile_lifecycle="trace",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "loguru",
     "pydantic>=2",
     "pydantic-settings>=2.2.1",
+    "sentry-sdk>=2.65.0",
     "sqlalchemy[asyncio]",
     "uvicorn[standard]",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from app import config as test_module
 
 
@@ -9,3 +12,13 @@ def test_configs():
         "postgresql+asyncpg://accounting_service:accounting_service@"
         f"{configs.DB_HOST}:{configs.DB_PORT}/accounting_service"
     ) == configs.DB_URI
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["SENTRY_TRACES_SAMPLE_RATE", "SENTRY_PROFILE_SESSION_SAMPLE_RATE"],
+)
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_configs_invalid_sentry_sample_rate(name, value):
+    with pytest.raises(ValidationError, match=name):
+        test_module.Settings(**{name: value})

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,19 @@
+import sentry_sdk
+
+from app import sentry as test_module
+from app.config import settings
+
+
+def test_init_sentry():
+    test_module.init_sentry()
+
+    client = sentry_sdk.get_client()
+    assert client.is_active()
+    assert client.transport is None  # without a DSN nothing is sent
+    assert client.options["environment"] == settings.DEPLOYMENT_ENV
+    assert client.options["release"] == settings.APP_VERSION
+    assert client.options["traces_sample_rate"] == settings.SENTRY_TRACES_SAMPLE_RATE
+    assert (
+        client.options["profile_session_sample_rate"] == settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE
+    )
+    assert client.options["profile_lifecycle"] == "trace"

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ dependencies = [
     { name = "loguru" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "sentry-sdk" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -44,6 +45,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
+    { name = "sentry-sdk", specifier = ">=2.65.0" },
     { name = "sqlalchemy", extras = ["asyncio"] },
     { name = "uvicorn", extras = ["standard"] },
 ]
@@ -821,6 +823,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
     { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
     { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.65.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/1f/ed17a390348156ca99fe622b97cd7d2f1969b5f49df89084b0f28e7953e9/sentry_sdk-2.65.0.tar.gz", hash = "sha256:c94dc945d54bad49d4f20448b1e6b217ca2f92f46d05c3e83d41764af685c3d1", size = 932133, upload-time = "2026-07-13T11:33:19.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/3b/326ad4c03b5da89b5124c8890af66e8119c4d2e10abc0619e0d67d9f7c7f/sentry_sdk-2.65.0-py3-none-any.whl", hash = "sha256:3595169677a808e4d0e1ea6ffb89443459549c7a98392ed71c77c847182ab6bf", size = 503869, upload-time = "2026-07-13T11:33:17.71Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add Sentry integration with tracing and continuous profiling. The SDK auto-enables the FastAPI, Starlette, SQLAlchemy, asyncpg and loguru integrations, so API errors, DB spans and `logger.exception` calls are captured without extra config.

`sentry_sdk.init` is called from `__main__.py` right after `configure_logging` (which removes all loguru sinks, including the ones registered by the Sentry loguru integration), so errors from the queue consumers and periodic chargers are captured as well, not only the API ones.

The environment comes from the new `DEPLOYMENT_ENV` setting (to be set by the deployment infra), the release from `APP_VERSION`. Sample rates are tunable via `SENTRY_TRACES_SAMPLE_RATE` and `SENTRY_PROFILE_SESSION_SAMPLE_RATE`, both defaulting to 1.