### PR TITLE
Prevent deadlocks by locking accounts before ledger operations

### DIFF
--- a/app/service/charge_longrun.py
+++ b/app/service/charge_longrun.py
@@ -43,6 +43,8 @@ async def _charge_generic(
         )
         return
     accounts = await repos.account.get_accounts_by_proj_id(proj_id=job.proj_id)
+    # Lock accounts upfront in deterministic order to prevent deadlocks
+    await repos.account.lock_accounts([accounts.rsv.id, accounts.proj.id, accounts.sys.id])
     price = await repos.price.get_price(
         vlab_id=accounts.vlab.id,
         service_type=job.service_type,

--- a/app/service/charge_oneshot.py
+++ b/app/service/charge_oneshot.py
@@ -19,6 +19,8 @@ async def _charge_generic(
     reason: str,
 ) -> None:
     accounts = await repos.account.get_accounts_by_proj_id(proj_id=job.proj_id)
+    # Lock accounts upfront in deterministic order to prevent deadlocks
+    await repos.account.lock_accounts([accounts.rsv.id, accounts.proj.id, accounts.sys.id])
     price = await repos.price.get_price(
         vlab_id=accounts.vlab.id,
         service_type=job.service_type,

--- a/app/service/charge_storage.py
+++ b/app/service/charge_storage.py
@@ -32,6 +32,8 @@ async def _charge_one(
         )
         return
     accounts = await repos.account.get_accounts_by_proj_id(proj_id=job.proj_id)
+    # Lock accounts upfront in deterministic order to prevent deadlocks
+    await repos.account.lock_accounts([accounts.proj.id, accounts.sys.id])
     price = await repos.price.get_price(
         vlab_id=accounts.vlab.id,
         service_type=job.service_type,

--- a/app/service/release.py
+++ b/app/service/release.py
@@ -35,6 +35,8 @@ async def _release_reservation(
         )
     with ensure_result(error_message="Account not found"):
         accounts = await repos.account.get_accounts_by_proj_id(proj_id=job.proj_id)
+    # Lock accounts upfront in deterministic order to prevent deadlocks
+    await repos.account.lock_accounts([accounts.rsv.id, accounts.proj.id])
     remaining_reservation = await repos.ledger.get_remaining_reservation_for_job(
         job_id=job.id, account_id=accounts.rsv.id, raise_if_negative=True
     )


### PR DESCRIPTION
Two concurrent transactions on the same project's accounts (e.g. a reservation release and the longrun usage consumer) could deadlock because account row locks were only acquired inside insert_transaction, too late in the transaction to prevent lock ordering conflicts.

When a service function calls insert_transaction multiple times, the first call locks and updates some accounts, and a concurrent transaction targeting the same accounts can interleave, creating a lock cycle.

Fix: acquire explicit FOR UPDATE locks on all involved accounts at the start of each service function, before any ledger reads or writes. The existing lock inside insert_transaction is kept as a safety net but is now effectively a no-op re-lock.


Fix https://github.com/openbraininstitute/prod-platform-architecture/issues/222
